### PR TITLE
Added support for QueryDSL's QueryDslPredicateExecutor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,21 @@
 			<version>2.8.2</version>
 		</dependency>
 
+		<!-- QueryDsl -->
+		<dependency>
+			<groupId>com.querydsl</groupId>
+			<artifactId>querydsl-apt</artifactId>
+			<version>${querydsl}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.querydsl</groupId>
+			<artifactId>querydsl-jpa</artifactId>
+			<version>${querydsl}</version>
+			<optional>true</optional>
+		</dependency>
+
 		<!-- Test -->
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/src/main/java/org/springframework/data/envers/repository/support/QueryDslWithEnversRevisionRepository.java
+++ b/src/main/java/org/springframework/data/envers/repository/support/QueryDslWithEnversRevisionRepository.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.envers.repository.support;
+
+import java.io.Serializable;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.history.Revision;
+import org.springframework.data.history.Revisions;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
+import org.springframework.data.jpa.repository.support.QueryDslJpaRepository;
+import org.springframework.data.repository.history.support.RevisionEntityInformation;
+
+/**
+ * Repository implementation for both {@link org.springframework.data.repository.history.RevisionRepository} and
+ * {@link org.springframework.data.querydsl.QueryDslPredicateExecutor} interfaces.
+ *
+ * @author Dmytro Iaroslavskyi
+ */
+public class QueryDslWithEnversRevisionRepository<T, ID extends Serializable, N extends Number & Comparable<N>>
+		extends QueryDslJpaRepository<T, ID> implements EnversRevisionRepository<T, ID, N> {
+
+	private final EnversRevisionRepositoryImpl<T, ID, N> delegateRepository;
+
+	/**
+	 * Creates a new {@link QueryDslWithEnversRevisionRepository} using the given {@link JpaEntityInformation}, {@link
+	 * RevisionEntityInformation} and {@link EntityManager}.
+	 *
+	 * @param entityInformation         must not be {@literal null}.
+	 * @param revisionEntityInformation must not be {@literal null}.
+	 * @param entityManager             must not be {@literal null}.
+	 */
+	public QueryDslWithEnversRevisionRepository(JpaEntityInformation<T, ID> entityInformation,
+			RevisionEntityInformation revisionEntityInformation, EntityManager entityManager) {
+		super(entityInformation, entityManager);
+		this.delegateRepository = new EnversRevisionRepositoryImpl<T, ID, N>(entityInformation, revisionEntityInformation,
+				entityManager);
+	}
+
+	@Override
+	public Revision<N, T> findLastChangeRevision(ID id) {
+		return delegateRepository.findLastChangeRevision(id);
+	}
+
+	@Override
+	public Revision<N, T> findRevision(ID id, N revisionNumber) {
+		return delegateRepository.findRevision(id, revisionNumber);
+	}
+
+	@Override
+	public Revisions<N, T> findRevisions(ID id) {
+		return delegateRepository.findRevisions(id);
+	}
+
+	@Override
+	public Page<Revision<N, T>> findRevisions(ID id, Pageable pageable) {
+		return delegateRepository.findRevisions(id, pageable);
+	}
+
+}

--- a/src/test/java/org/springframework/data/envers/repository/support/QueryDslRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/envers/repository/support/QueryDslRepositoryIntegrationTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.envers.repository.support;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.envers.Config;
+import org.springframework.data.envers.sample.Country;
+import org.springframework.data.envers.sample.CountryQueryDslRepository;
+import org.springframework.data.envers.sample.QCountry;
+import org.springframework.data.history.Revision;
+import org.springframework.data.history.Revisions;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Iterator;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Integration tests for repositories with QueryDsl support. They make sure that methods provided by both
+ * {@link EnversRevisionRepository} and {@link org.springframework.data.querydsl.QueryDslPredicateExecutor} are working.
+ *
+ * @author Dmytro Iaroslavskyi
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = Config.class)
+public class QueryDslRepositoryIntegrationTests {
+
+	@Autowired CountryQueryDslRepository countryRepository;
+
+	@Before
+	public void setUp() {
+		countryRepository.deleteAll();
+	}
+
+	@Test
+	public void testWithQueryDsl() {
+
+		Country de = new Country();
+		de.code = "de";
+		de.name = "Deutschland";
+
+		countryRepository.save(de);
+
+		Country found = countryRepository.findOne(QCountry.country.name.eq("Deutschland"));
+
+		assertThat(found, is(notNullValue()));
+		assertThat(found.id, is(de.id));
+
+	}
+
+	@Test
+	public void testWithRevisions() {
+
+		Country de = new Country();
+		de.code = "de";
+		de.name = "Deutschland";
+
+		countryRepository.save(de);
+
+		de.name = "Germany";
+
+		countryRepository.save(de);
+
+		Revisions<Integer, Country> revisions = countryRepository.findRevisions(de.id);
+
+		assertThat(revisions, is(Matchers.<Revision<Integer, Country>>iterableWithSize(2)));
+
+		Iterator<Revision<Integer, Country>> iterator = revisions.iterator();
+		Revision<Integer, Country> first = iterator.next();
+		Revision<Integer, Country> second = iterator.next();
+
+		assertThat(countryRepository.findRevision(de.id, first.getRevisionNumber()).getEntity().name, is("Deutschland"));
+		assertThat(countryRepository.findRevision(de.id, second.getRevisionNumber()).getEntity().name, is("Germany"));
+
+	}
+
+}

--- a/src/test/java/org/springframework/data/envers/sample/CountryQueryDslRepository.java
+++ b/src/test/java/org/springframework/data/envers/sample/CountryQueryDslRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.envers.sample;
+
+import org.springframework.data.envers.repository.support.EnversRevisionRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QueryDslPredicateExecutor;
+
+/**
+ * Repository with QueryDsl support for {@link Country} objects.
+ *
+ * @author Dmytro Iaroslavskyi
+ */
+public interface CountryQueryDslRepository
+		extends EnversRevisionRepository<Country, Long, Integer>, JpaRepository<Country, Long>,
+		QueryDslPredicateExecutor<Country> {
+
+}

--- a/src/test/java/org/springframework/data/envers/sample/QCountry.java
+++ b/src/test/java/org/springframework/data/envers/sample/QCountry.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.envers.sample;
+
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import com.querydsl.core.types.dsl.PathInits;
+import com.querydsl.core.types.dsl.StringPath;
+
+import static com.querydsl.core.types.PathMetadataFactory.forVariable;
+
+/**
+ * Query class for Country domain.
+ *
+ * @author Dmytro Iaroslavskyi
+ */
+public class QCountry extends EntityPathBase<Country> {
+
+	private static final long serialVersionUID = -936338527;
+
+	private static final PathInits INITS = PathInits.DIRECT2;
+
+	public static final QCountry country = new QCountry("country");
+
+	public final StringPath code = createString("code");
+	public final StringPath name = createString("name");
+
+	public QCountry(String variable) {
+		this(Country.class, forVariable(variable), INITS);
+	}
+
+	@SuppressWarnings("all")
+	public QCountry(Path<? extends Country> path) {
+		this((Class) path.getType(), path.getMetadata(), path.getMetadata().isRoot() ? INITS : PathInits.DEFAULT);
+	}
+
+	public QCountry(PathMetadata metadata) {
+		this(metadata, metadata.isRoot() ? INITS : PathInits.DEFAULT);
+	}
+
+	public QCountry(PathMetadata metadata, PathInits inits) {
+		this(Country.class, metadata, inits);
+	}
+
+	public QCountry(Class<? extends Country> type, PathMetadata metadata, PathInits inits) {
+		super(type, metadata, inits);
+	}
+
+}


### PR DESCRIPTION
Support for QueryDSL's QueryDslPredicateExecutor was added. This improvement solves issue https://github.com/spring-projects/spring-data-envers/issues/30.

As a side effect, dependency on ```com.querydsl:querydsl-apt``` and ```com.querydsl:querydsl-jpa``` was added. But I assume this is not an issue, because ```org.springframework.data:spring-data-jpa``` already depends on these artifacts.
