### PR TITLE
Querydsl support 1 9 0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
 	<properties>
 		<spring.version>4.0.9.RELEASE</spring.version>
 		<spring.data.jpa.version>1.8.0.RELEASE</spring.data.jpa.version>
+		<querydsl>3.6.2</querydsl>
 		<slf4j.version>1.7.10</slf4j.version>
 		<file.encoding>UTF-8</file.encoding>
 	</properties>
@@ -114,6 +115,21 @@
 			<version>${spring.version}</version>
 		</dependency>
 
+		<!-- QueryDsl -->
+		<dependency>
+			<groupId>com.mysema.querydsl</groupId>
+			<artifactId>querydsl-apt</artifactId>
+			<version>${querydsl}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.mysema.querydsl</groupId>
+			<artifactId>querydsl-jpa</artifactId>
+			<version>${querydsl}</version>
+			<optional>true</optional>
+		</dependency>
+		
 		<!-- Logging -->
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>0.3.0.BUILD-SNAPSHOT</version>
+	<version>0.3.0.DSLQUERY-SNAPSHOT</version>
 
 	<name>Spring Data Envers</name>
 	<description>Spring Data extension to work with Hibernate Envers</description>
@@ -59,7 +59,7 @@
 
 	<properties>
 		<spring.version>4.0.9.RELEASE</spring.version>
-		<spring.data.jpa.version>1.8.0.RELEASE</spring.data.jpa.version>
+		<spring.data.jpa.version>1.9.0.RELEASE</spring.data.jpa.version>
 		<querydsl>3.6.2</querydsl>
 		<slf4j.version>1.7.10</slf4j.version>
 		<file.encoding>UTF-8</file.encoding>

--- a/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryFactoryBean.java
@@ -99,17 +99,14 @@ public class EnversRevisionRepositoryFactoryBean extends
 	            RepositoryInformation information, EntityManager entityManager) {
 
 	        JpaEntityInformation<?, Serializable> entityInformation = getEntityInformation(information.getDomainType());
-	        
-	        //return getTargetRepository(entityInformation, entityManager);
 	        Class<?> repoBaseClass = information.getRepositoryBaseClass();
 	        SimpleJpaRepository<?, ?> result = null;
 	        if(RevisionRepository.class.isAssignableFrom(repoBaseClass)) {
 	            result = getTargetRepositoryViaReflection(information, entityInformation, revisionEntityInformation, entityManager);
 	        }
 	        else { 
-	          result = getTargetRepositoryViaReflection(information, entityInformation, entityManager);
+	          result = super.getTargetRepository(information, entityManager);
 	        }
-	        
 	        return result;
 	    }
 

--- a/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryFactoryBean.java
@@ -26,6 +26,8 @@ import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactory;
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
+import org.springframework.data.querydsl.QueryDslPredicateExecutor;
+import org.springframework.data.querydsl.QueryDslUtils;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.data.repository.history.RevisionRepository;
@@ -102,9 +104,23 @@ public class EnversRevisionRepositoryFactoryBean extends
 		 */
 		@Override
 		protected Class<?> getRepositoryBaseClass(RepositoryMetadata metadata) {
-			return EnversRevisionRepositoryImpl.class;
+			if (isQueryDslExecutor(metadata.getRepositoryInterface())) {
+				return QueryDslWithEnversRevisionRepository.class;
+			} else {
+				return EnversRevisionRepositoryImpl.class;
+			}
 		}
 
+		/**
+		 * Returns whether the given repository interface requires a QueryDsl specific implementation to be chosen.
+		 * 
+		 * @param repositoryInterface
+		 * @return
+		 */
+		private boolean isQueryDslExecutor(Class<?> repositoryInterface) {
+			return QueryDslUtils.QUERY_DSL_PRESENT && QueryDslPredicateExecutor.class.isAssignableFrom(repositoryInterface);
+		}
+		
 		/* 
 		 * (non-Javadoc)
 		 * @see org.springframework.data.repository.core.support.RepositoryFactorySupport#getRepository(java.lang.Class, java.lang.Object)

--- a/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryFactoryBean.java
@@ -22,12 +22,14 @@ import javax.persistence.EntityManager;
 import org.hibernate.envers.DefaultRevisionEntity;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.core.GenericTypeResolver;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactory;
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 import org.springframework.data.querydsl.QueryDslPredicateExecutor;
 import org.springframework.data.querydsl.QueryDslUtils;
+import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.data.repository.history.RevisionRepository;
@@ -84,19 +86,46 @@ public class EnversRevisionRepositoryFactoryBean extends
 					: new ReflectionRevisionEntityInformation(revisionEntityClass);
 		}
 
+	    /**
+	     * Callback to create a {@link JpaRepository} instance with the given {@link EntityManager}
+	     * 
+	     * @param <T>
+	     * @param <ID>
+	     * @param entityManager
+	     * @see #getTargetRepository(RepositoryMetadata)
+	     * @return
+	     */
+	    protected <T, ID extends Serializable> SimpleJpaRepository<?, ?> getTargetRepository(
+	            RepositoryInformation information, EntityManager entityManager) {
+
+	        JpaEntityInformation<?, Serializable> entityInformation = getEntityInformation(information.getDomainType());
+	        
+	        //return getTargetRepository(entityInformation, entityManager);
+	        Class<?> repoBaseClass = information.getRepositoryBaseClass();
+	        SimpleJpaRepository<?, ?> result = null;
+	        if(RevisionRepository.class.isAssignableFrom(repoBaseClass)) {
+	            result = getTargetRepositoryViaReflection(information, entityInformation, revisionEntityInformation, entityManager);
+	        }
+	        else { 
+	          result = getTargetRepositoryViaReflection(information, entityInformation, entityManager);
+	        }
+	        
+	        return result;
+	    }
+
 		/* 
 		 * (non-Javadoc)
 		 * @see org.springframework.data.jpa.repository.support.JpaRepositoryFactory#getTargetRepository(org.springframework.data.repository.core.RepositoryMetadata, javax.persistence.EntityManager)
-		 */
+		 * /
 		@Override
 		@SuppressWarnings({ "unchecked", "rawtypes" })
 		protected <T, ID extends Serializable> SimpleJpaRepository<?, ?> getTargetRepository(RepositoryMetadata metadata,
-				EntityManager entityManager) {
+		    JpaEntityInformation<?, Serializable> entityInformation, EntityManager entityManager) {
 
 			JpaEntityInformation<T, Serializable> entityInformation = (JpaEntityInformation<T, Serializable>) getEntityInformation(metadata
 					.getDomainType());
 			return new EnversRevisionRepositoryImpl(entityInformation, revisionEntityInformation, entityManager);
-		}
+		}*/
 
 		/*
 		 * (non-Javadoc)

--- a/src/main/java/org/springframework/data/envers/repository/support/QueryDslWithEnversRevisionRepository.java
+++ b/src/main/java/org/springframework/data/envers/repository/support/QueryDslWithEnversRevisionRepository.java
@@ -1,0 +1,55 @@
+package org.springframework.data.envers.repository.support;
+
+import java.io.Serializable;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.history.Revision;
+import org.springframework.data.history.Revisions;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
+import org.springframework.data.jpa.repository.support.QueryDslJpaRepository;
+import org.springframework.data.repository.history.support.RevisionEntityInformation;
+
+public class QueryDslWithEnversRevisionRepository<T, ID extends Serializable, N extends Number & Comparable<N>>
+		extends QueryDslJpaRepository<T, ID> implements EnversRevisionRepository<T, ID, N> {
+
+	private final EnversRevisionRepositoryImpl<T, ID, N> delegateRepository;
+
+	/**
+	 * Creates a new {@link QueryDslWithEnversRevisionRepository} using the given {@link JpaEntityInformation},
+	 * {@link RevisionEntityInformation} and {@link EntityManager}.
+	 *
+	 * @param entityInformation must not be {@literal null}.
+	 * @param revisionEntityInformation must not be {@literal null}.
+	 * @param entityManager must not be {@literal null}.
+	 */
+	public QueryDslWithEnversRevisionRepository(JpaEntityInformation<T, ID> entityInformation,
+			RevisionEntityInformation revisionEntityInformation, EntityManager entityManager) {
+		super(entityInformation, entityManager);
+		this.delegateRepository = new EnversRevisionRepositoryImpl<T, ID, N>(entityInformation, revisionEntityInformation,
+				entityManager);
+	}
+
+	@Override
+	public Revision<N, T> findLastChangeRevision(ID id) {
+		return delegateRepository.findLastChangeRevision(id);
+	}
+
+	@Override
+	public Revision<N, T> findRevision(ID id, N revisionNumber) {
+		return delegateRepository.findRevision(id, revisionNumber);
+	}
+
+	@Override
+	public Revisions<N, T> findRevisions(ID id) {
+		return delegateRepository.findRevisions(id);
+	}
+
+	@Override
+	public Page<Revision<N, T>> findRevisions(ID id, Pageable pageable) {
+		return delegateRepository.findRevisions(id, pageable);
+	}
+
+}


### PR DESCRIPTION
Contains Dmytr's integration of query-dsl support  (https://github.com/spring-projects/spring-data-envers/pull/37).
Modified factory-class to to support spring.data.jpa.version 1.9.0 by overriding the getTargetRepository to pass three args to the base-class constructor instead of the usual two in the parent class (JPARepositoryFactory).
Contains the POM changes required as well- this supercedes the other pull request (https://github.com/spring-projects/spring-data-envers/pull/36) for 1.9.0 since this request contains more than just POM changes and method param-type change.