### PR TITLE
Update to Hibernate 5.2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 	<properties>
 		<springdata.commons>2.0.0.BUILD-SNAPSHOT</springdata.commons>
 		<springdata.jpa>2.0.0.BUILD-SNAPSHOT</springdata.jpa>
-		<hibernate.envers>4.3.11</hibernate.envers>
+		<hibernate.envers>5.2.11</hibernate.envers>
 		<java-module-name>spring.data.envers</java-module-name>
 	</properties>
 


### PR DESCRIPTION
Update `hibernate-envers` dependency to latest version at this time (5.2.11). The API didn't changed, so it's just a matter of transitive dependencies since `spring-data-jpa` depends on Hibernate 5.2 which conflicts with 4.3.