### PR TITLE
DefaultRevisionMetadata.getRevisionDate does not work in 2.0 (#112)

### DIFF
--- a/src/test/java/org/springframework/data/envers/repository/support/DefaultRevisionMetadataTest.java
+++ b/src/test/java/org/springframework/data/envers/repository/support/DefaultRevisionMetadataTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.envers.repository.support;
+
+import org.hibernate.envers.DefaultRevisionEntity;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Benedikt Ritter
+ */
+public class DefaultRevisionMetadataTest {
+
+	private static final LocalDateTime NOW = LocalDateTime.now();
+
+	@Test
+	public void createsLocalDateTimeFromTimestamp() {
+		DefaultRevisionEntity entity = new DefaultRevisionEntity();
+		entity.setTimestamp(NOW.toEpochSecond(ZoneOffset.UTC));
+		DefaultRevisionMetadata metadata = new DefaultRevisionMetadata(entity);
+
+		assertThat(metadata.getRevisionDate()).hasValue(NOW);
+	}
+}


### PR DESCRIPTION
See #112: It looks like `DefaultRevisionMetadata.getRevisionDate()` does not work anymore in 2.0. This PR just adds a test showing this.

Before I create a fix for this I'd like to discuss how this should be fixed. Currently the code uses `LocalDateTime.from(TemporalAccessor)` which does not work with `Instant` objects. Instead one has to use `LocalDateTime.ofInstant(Instant, ZoneId)`. The problem here ist that the timestamp returned from `org.hibernate.envers.DefaultRevisionEntity.getTimestamp()` does not have zone information, so we can not know which `ZoneId` to use when creating the `LocalDateTime` instance.