### PR TITLE
#112 - Fixed DefaultRevisionMetadata.getRevisionDate. 

### DIFF
--- a/src/main/java/org/springframework/data/envers/repository/support/DefaultRevisionMetadata.java
+++ b/src/main/java/org/springframework/data/envers/repository/support/DefaultRevisionMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import lombok.Value;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 
 import org.hibernate.envers.DefaultRevisionEntity;
@@ -32,6 +33,7 @@ import org.springframework.data.history.RevisionMetadata;
  * 
  * @author Oliver Gierke
  * @author Philip Huegelmeyer
+ * @author Jens Schauder
  */
 @Value
 public class DefaultRevisionMetadata implements RevisionMetadata<Integer> {
@@ -51,7 +53,7 @@ public class DefaultRevisionMetadata implements RevisionMetadata<Integer> {
 	 * @see org.springframework.data.history.RevisionMetadata#getRevisionDate()
 	 */
 	public Optional<LocalDateTime> getRevisionDate() {
-		return Optional.of(LocalDateTime.from(Instant.ofEpochMilli(entity.getTimestamp())));
+		return Optional.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(entity.getTimestamp()), ZoneOffset.UTC));
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/envers/repository/support/DefaultRevisionMetadataUnitTests.java
+++ b/src/test/java/org/springframework/data/envers/repository/support/DefaultRevisionMetadataUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,24 +18,31 @@ package org.springframework.data.envers.repository.support;
 import org.hibernate.envers.DefaultRevisionEntity;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
+ * Unit tests for {@link DefaultRevisionMetadata}.
+ *
  * @author Benedikt Ritter
+ * @author Jens Schauder
  */
 public class DefaultRevisionMetadataUnitTests {
 
-	private static final LocalDateTime NOW = LocalDateTime.now();
+	private static final Instant NOW = Instant.now();;
 
-	@Test
+	@Test // #112
 	public void createsLocalDateTimeFromTimestamp() {
+
 		DefaultRevisionEntity entity = new DefaultRevisionEntity();
-		entity.setTimestamp(NOW.toEpochSecond(ZoneOffset.UTC));
+		entity.setTimestamp(NOW.toEpochMilli());
+
 		DefaultRevisionMetadata metadata = new DefaultRevisionMetadata(entity);
 
-		assertThat(metadata.getRevisionDate()).hasValue(NOW);
+		assertThat(metadata.getRevisionDate()).hasValue(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC));
 	}
 }

--- a/src/test/java/org/springframework/data/envers/repository/support/DefaultRevisionMetadataUnitTests.java
+++ b/src/test/java/org/springframework/data/envers/repository/support/DefaultRevisionMetadataUnitTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.envers.repository.support;
+
+import org.hibernate.envers.DefaultRevisionEntity;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Benedikt Ritter
+ */
+public class DefaultRevisionMetadataUnitTests {
+
+	private static final LocalDateTime NOW = LocalDateTime.now();
+
+	@Test
+	public void createsLocalDateTimeFromTimestamp() {
+		DefaultRevisionEntity entity = new DefaultRevisionEntity();
+		entity.setTimestamp(NOW.toEpochSecond(ZoneOffset.UTC));
+		DefaultRevisionMetadata metadata = new DefaultRevisionMetadata(entity);
+
+		assertThat(metadata.getRevisionDate()).hasValue(NOW);
+	}
+}


### PR DESCRIPTION
Assuming UTC time zone for converting the long into a LocalDateTime.