### PR TITLE
 #116 - Implemented getRevisionInstant.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.116-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>

--- a/src/main/java/org/springframework/data/envers/repository/support/DefaultRevisionMetadata.java
+++ b/src/main/java/org/springframework/data/envers/repository/support/DefaultRevisionMetadata.java
@@ -52,8 +52,19 @@ public class DefaultRevisionMetadata implements RevisionMetadata<Integer> {
 	 * (non-Javadoc)
 	 * @see org.springframework.data.history.RevisionMetadata#getRevisionDate()
 	 */
+	@Deprecated
 	public Optional<LocalDateTime> getRevisionDate() {
-		return Optional.of(LocalDateTime.ofInstant(Instant.ofEpochMilli(entity.getTimestamp()), ZoneOffset.systemDefault()));
+		return getRevisionInstant().map(instant -> LocalDateTime.ofInstant(instant, ZoneOffset.systemDefault()));
+	}
+
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.history.RevisionMetadata#getRevisionInstant()
+	 */
+	@Override
+	public Optional<Instant> getRevisionInstant() {
+		return Optional.of(Instant.ofEpochMilli(entity.getTimestamp()));
 	}
 
 	/*


### PR DESCRIPTION
Implemented the missing new method getRevisionInstant by extracting part of getRevisionDate.
This makes DefaultRevisionMetadata compile again.

Decided against a default implementation on the interface side since it would just hide the fact that the interface changed.