### PR TITLE
#21 Support finding deleted entity's revisions for 1.1.x.

### DIFF
--- a/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryImpl.java
+++ b/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryImpl.java
@@ -43,7 +43,9 @@ import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 import org.springframework.data.repository.core.EntityInformation;
 import org.springframework.data.repository.history.support.RevisionEntityInformation;
+import org.springframework.data.util.Pair;
 import org.springframework.util.Assert;
+import org.springframework.util.StreamUtils;
 
 /**
  * Repository implementation using Hibernate Envers to implement revision specific query methods.
@@ -128,7 +130,7 @@ public class EnversRevisionRepositoryImpl<T, ID extends Serializable, N extends 
 		AuditReader reader = AuditReaderFactory.get(entityManager);
 		List<? extends Number> revisionNumbers = reader.getRevisions(type, id);
 
-		return revisionNumbers.isEmpty() ? new Revisions<N, T>(Collections.EMPTY_LIST)
+		return revisionNumbers.isEmpty() ? new Revisions<N, T>(Collections.<Revision<N,T>>emptyList())
 				: getEntitiesForRevisions((List<N>) revisionNumbers, id, reader);
 	}
 
@@ -182,7 +184,7 @@ public class EnversRevisionRepositoryImpl<T, ID extends Serializable, N extends 
 				new HashSet<Number>(revisionNumbers));
 
 		for (Number number : revisionNumbers) {
-			revisions.put((N) number, reader.find(type, id, number));
+			revisions.put((N) number, reader.find(type, type.getName(), id, number, true));
 		}
 
 		return new Revisions<N, T>(toRevisions(revisions, revisionEntities));

--- a/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryImpl.java
+++ b/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryImpl.java
@@ -53,6 +53,7 @@ import org.springframework.util.StreamUtils;
  * @author Oliver Gierke
  * @author Philipp Huegelmeyer
  * @author Michael Igler
+ * @author Hanbyul Lee
  */
 public class EnversRevisionRepositoryImpl<T, ID extends Serializable, N extends Number & Comparable<N>>
 		extends SimpleJpaRepository<T, ID> implements EnversRevisionRepository<T, ID, N> {

--- a/src/test/java/org/springframework/data/envers/repository/support/RepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/envers/repository/support/RepositoryIntegrationTests.java
@@ -45,6 +45,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * Integration tests for repositories.
  * 
  * @author Oliver Gierke
+ * @author Hanbyul Lee
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = Config.class)

--- a/src/test/java/org/springframework/data/envers/repository/support/RepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/envers/repository/support/RepositoryIntegrationTests.java
@@ -151,4 +151,27 @@ public class RepositoryIntegrationTests {
 		assertThat(content, hasSize(2));
 		assertThat(content.get(0).getRevisionNumber(), is(greaterThan(content.get(1).getRevisionNumber())));
 	}
+
+	/**
+	 * @see #21
+	 */
+	@Test
+	public void findsDeletedRevisions() {
+		final int REVISION_COUNT = 2;
+
+		Country korea = new Country();
+		korea.code = "ko";
+		korea.name = "Korea";
+
+		countryRepository.save(korea);
+		countryRepository.delete(korea);
+
+		Revisions<Integer, Country> revisions = countryRepository.findRevisions(korea.id);
+
+		assertThat(revisions, Matchers.<Revision<Integer, Country>>iterableWithSize(REVISION_COUNT));
+		assertThat(revisions.getLatestRevision().getEntity(), notNullValue());
+		assertThat(revisions.getLatestRevision().getEntity().name, nullValue());
+		assertThat(revisions.getLatestRevision().getEntity().code, nullValue());
+
+	}
 }


### PR DESCRIPTION
Support finding deleted entity's revisions which had to been implemented for 1.1.x.