### PR TITLE
#146 - Directly return empty result when querying for empty list of revisions.

### DIFF
--- a/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryImpl.java
+++ b/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryImpl.java
@@ -52,6 +52,7 @@ import org.springframework.util.Assert;
  * @author Philipp Huegelmeyer
  * @author Michael Igler
  * @author Jens Schauder
+ * @author Julien Millau
  */
 @Transactional(readOnly = true)
 public class EnversRevisionRepositoryImpl<T, ID, N extends Number & Comparable<N>>
@@ -150,8 +151,8 @@ public class EnversRevisionRepositoryImpl<T, ID, N extends Number & Comparable<N
 			Collections.reverse(revisionNumbers);
 		}
 
-		if (pageable.getOffset() > revisionNumbers.size()) {
-			return new PageImpl<Revision<N, T>>(Collections.<Revision<N, T>> emptyList(), pageable, 0);
+		if (revisionNumbers.isEmpty() || pageable.getOffset() > revisionNumbers.size()) {
+			return Page.empty(pageable);
 		}
 
 		long upperBound = pageable.getOffset() + pageable.getPageSize();


### PR DESCRIPTION
With postgres when no revisions exist for an entity the method `findRevisions` fail with `ERROR: syntax error at or near ")"` due to an empty IN clause in the generated request.

Close #146

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in [Github issues](https://github.com/spring-projects/spring-data-envers/issues).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
