### PR TITLE
#225 Delete licenses so later tests can pass

### DIFF
--- a/src/test/java/org/springframework/data/envers/repository/support/RepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/envers/repository/support/RepositoryIntegrationTests.java
@@ -97,6 +97,7 @@ public class RepositoryIntegrationTests {
 			Revisions<Integer, License> revisions = Revisions.of(page.getContent());
 			assertThat(revisions.getLatestRevision()).isEqualTo(it);
 		});
+		licenseRepository.deleteAll();
 	}
 
 	@Test // #1


### PR DESCRIPTION
Addresses issue #225 by adding call to delete licenses from `licenseRepository` at the end of `testLifeCycle`.

@pivotal-issuemaster This is an Obvious Fix